### PR TITLE
Fix for php 8 compatibility

### DIFF
--- a/format.php
+++ b/format.php
@@ -72,7 +72,7 @@ class qformat_printout extends qformat_default {
         }
 
         // Print questions depends on question type.
-        $expout .= "<div>";
+        $expout = "<div>";
         switch($question->qtype) {
             case 'multichoice':
                 $expout .= $this->writetitle($question->questiontext);
@@ -163,18 +163,19 @@ class qformat_printout extends qformat_default {
                 break;
             default:
                 $expout .= $this->writetitle($question->questiontext);
-                if (count($question->options->answers) > 1) {
+                $answers = $question->options->answers ?? [];
+                if (count($answers) > 1) {
                     $expout .= "<ul>";
-                    foreach ($question->options->answers as $answer) {
+                    foreach ($answers as $answer) {
                         $expout .= "<li>". strip_tags($answer->answer) ."</li>";
                     }
                     $expout .= "</ul>";
                 } else {
-                    foreach ($question->options->answers as $answer) {
+                    foreach ($answers as $answer) {
                         $expout .= "<p>" . get_string('answer') . ": " . strip_tags($answer->answer) . "</p>";
                     }
                 }
-            $expout .= "<br>";
+                $expout .= "<br>";
         }
 
         // Feedback.
@@ -186,7 +187,8 @@ class qformat_printout extends qformat_default {
         // Question type.
         $expout .= "<p class=\"questiontype\">{$question->name} ";
         $expout .= " (" . get_string('pluginname', "qtype_{$question->qtype}");
-        if ($question->options->single) {
+
+        if (!empty($question->options->single)) {
             $expout .= " / " . get_string('answersingleyes', 'qtype_multichoice');
         }
         $expout .= ")</p>";


### PR DESCRIPTION
There are some compatibility issues for php 8+.

https://www.php.net/manual/en/migration80.incompatible.php


Fix the issue below:

```
/question/format/printout/format.php75
Undefined variable $expout
```

```
/question/format/printout/format.php191
Undefined property: stdClass::$single
```

I'm not sure how I can replicate the issue https://github.com/stemiwe/moodle-qformat_printout/issues/6 but it should be a compatibility issue, so I fixed it here as well.

A number of notices have been converted into warnings:
- Attempting to read an undefined variable.
- Attempting to read an undefined property.

A number of warnings have been converted into Error exceptions:
- Passing invalid countable types to count() will throw a TypeError.